### PR TITLE
Fix bottom padding for chat input

### DIFF
--- a/code/interview.py
+++ b/code/interview.py
@@ -435,6 +435,10 @@ if st.session_state.interview_active:
             z-index: 9999;
         }
         .fixed-input-wrapper .block-container { padding: 0; }
+        .appview-container .main .block-container {
+            padding-bottom: 6rem;
+        }
+        body { padding-bottom: 6rem; }
         </style>
         """,
         unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- style input wrapper to leave bottom space so it doesn't overlap messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863b3fe0924832286007119e1f27ac2