### PR TITLE
Fix floating input

### DIFF
--- a/code/interview.py
+++ b/code/interview.py
@@ -435,6 +435,8 @@ if st.session_state.interview_active:
             z-index: 9999;
         }
         .fixed-input-wrapper .block-container { padding: 0; }
+        /* Ensure chat content isn't hidden behind the fixed input */
+        .block-container { padding-bottom: 5rem; }
         </style>
         """,
         unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- keep chat input pinned but add bottom padding so messages aren't hidden

## Testing
- `pytest -q`
- `python -m py_compile code/interview.py`


------
https://chatgpt.com/codex/tasks/task_e_6863b3fe0924832286007119e1f27ac2